### PR TITLE
修复命令行下seed为数组时获取不到url

### DIFF
--- a/src/Beanbun.php
+++ b/src/Beanbun.php
@@ -390,6 +390,12 @@ class Beanbun
             $this->queue = $queue = $this->queue()->next();
         } else {
             $queue = array_shift($this->seed);
+            if (is_array($queue)) {
+				$queue = [
+					'url' => $queue[0],
+					'options' => $queue[1],
+				];
+			}
         }
 
         if (is_null($queue) || !$queue) {


### PR DESCRIPTION
命令行下运行时，seed设置为数组，会导致获取不到url，curl报错`cURL error 3: <url>`