### PR TITLE
当网页网址末尾是`/`的目录形式时，页面url路径错误

### DIFF
--- a/src/Lib/Helper.php
+++ b/src/Lib/Helper.php
@@ -79,7 +79,7 @@ class Helper
             while (substr($I1, 0, 3) == '../') {
                 $I1 = substr($I1, strlen($I1) - (strlen($I1) - 3), strlen($I1) - 3);
                 if (strlen($path) > 0) {
-                    $path = dirname($path);
+                    $path = dirname($path.'a');
                 }
             }
             return $I1 = $path == '/' ? $l3 . $path . $I1 : $l3 . $path . "/" . $I1;

--- a/src/Lib/Helper.php
+++ b/src/Lib/Helper.php
@@ -61,7 +61,7 @@ class Helper
         if (strlen($l3) == 0) {
             return $l1;
         }
-        $path = dirname($url_parsed['path']);
+        $path = dirname($url_parsed['path'].'a');
         if ($path[0] == '\\') {
             $path = '';
         }


### PR DESCRIPTION
如果最后一个/后无字符，dirname 命令使用倒数第二个/，添加个字符a使其使用最后一个/